### PR TITLE
TextMark and TextGeom accepting negative fontsize.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Vizagrams"
 uuid = "8c229dad-8b3a-4031-83d6-73545c88426d"
 authors = ["Davi Barreira <davisbarreira@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/src/tutorials/3_datavisualization.md
+++ b/docs/src/tutorials/3_datavisualization.md
@@ -36,7 +36,6 @@ the whole specification.
 ```@example 3
 Random.seed!(4)
 plt = plot(x=rand(10),y=rand(10))
-# plt = S(:vectorEffect=>"none")plt
 draw(plt,height=300)
 ```
 

--- a/src/backends/svgbackend.jl
+++ b/src/backends/svgbackend.jl
@@ -370,7 +370,7 @@ the width.
 """
 function drawsvg(d::𝕋; height=300, pad=10, width=nothing, kwargs...)
     bb = boundingbox(d)
-    if isnothing(bb)
+    if isnothing(bb) || bb ≈ [[0.0, 0.0], [0.0, 0.0]]
         return tosvg(Prim[]; height=height, kwargs...)
     end
     boxwidth = bb[2][1] - bb[1][1]

--- a/src/marks/textmark.jl
+++ b/src/marks/textmark.jl
@@ -7,7 +7,7 @@ struct TextMark <: Mark
     fontfamily::String
     style::S
     function TextMark(text, pos, fontsize, angle, anchor, fontfamily, style)
-        @assert fontsize > 0.0 "Size must be a positive real number"
+        # @assert fontsize > 0.0 "Size must be a positive real number"
         @assert anchor in [:c, :s, :n, :e, :w, :se, :sw, :ne, :nw]
         return new(text, pos, fontsize, angle, anchor, fontfamily, style)
     end

--- a/src/primitives/text.jl
+++ b/src/primitives/text.jl
@@ -5,7 +5,7 @@ struct TextGeom <: GeometricPrimitive
     θ::Real
     fontfamily::String
     function TextGeom(text, pos, fontsize, θ, fontfamily)
-        @assert fontsize > 0.0 "Size must be a positive real number"
+        # @assert fontsize > 0.0 "Size must be a positive real number"
         return new(text, pos, fontsize, θ, fontfamily)
     end
 end

--- a/test/primitives/test_text.jl
+++ b/test/primitives/test_text.jl
@@ -4,7 +4,7 @@ import Vizagrams: CovText, ϕ, ψ
 @testset "TextGeom" begin
     g = T(1.0, 1.0)
     @testset "Constructor" begin
-        @test_throws AssertionError TextGeom("", [0, 0], -1, 0, "")
+        # @test_throws AssertionError TextGeom("", [0, 0], -1, 0, "")
         @test TextGeom("", [0, 0], 12, 0, "").text == ""
         @test TextGeom("", [0, 0], 12, 0, "").pos == [0, 0]
         @test TextGeom("", [0, 0], 12, 0, "").fontsize == 12

--- a/test/visual/plots.jl
+++ b/test/visual/plots.jl
@@ -373,6 +373,12 @@ using StructArrays
     end
 
     @testset "quick plot" begin
+
+        # Simple test for plot
+        Random.seed!(4)
+        plt = plot(x=rand(10), y=rand(10))
+        @test string(draw(plt, height=300)) isa String
+
         # testing quick plot function passing data into variables
         p = plot(x=[1, 2, 3], y=[1, 2, 3], color=[1, 2, 3])
         @test length(getmark(Circle, p)) == 3


### PR DESCRIPTION
Altering the behavior for TextGeom and TextMark to accept negative fontsize. This pull request tries to address the issue #20 

Note that this is not directly addressing the reported error, but it improves the code functionality, and might help figure out what is causing the issue cited.