### PR TITLE
Adjusting Frame and getmarkpath

### DIFF
--- a/src/auxiliar/treemanipulation.jl
+++ b/src/auxiliar/treemanipulation.jl
@@ -197,7 +197,6 @@ Returns
 [g*m1, s*m2]
 ```
 """
-# getmarkpath(M::Type, d::TMark) = cata(x -> getmarkpath(M, x), fmap(x -> Mark[x], d))
 function getmarkpath(M::Type, d::TMark)
     return cata(x -> getmarkpath(M, x), fmap(x -> getmarkpathvec(M, x), d))
 end
@@ -210,4 +209,19 @@ function getmarkpath(M::Type, d::Union{TMark,Mark}, g::Type{G})
 end
 function getmarkpath(M::Type, d::Union{TMark,Mark}, g::Type{S})
     return map(x -> x._1[2], getmarkpath(M, d))
+end
+
+
+"""
+getmarkpath(M::Vector{DataType}, d::Union{TMark,Mark})
+
+Given a TMark tree and a list of mark types, this function extracts a `Vector{TMark}`.
+"""
+function getmarkpath(M::Vector{DataType}, d::Union{TMark,Mark})
+    return getmarkpath(M, [d])
+end
+function getmarkpath(M::Vector{DataType}, d::Vector)
+    ap(t, diag) = mapreduce(x -> μ(fmap(ζ, x)), vcat, getmarkpath(t, diag))
+    vap(t, ds) = mapreduce(v -> mapreduce(x -> μ(fmap(ζ, x)), vcat, getmarkpath(t, v)), vcat, ds)
+    return foldl((acc, t) -> vap(t, acc), M, init=d)
 end

--- a/src/auxiliar/treemanipulation.jl
+++ b/src/auxiliar/treemanipulation.jl
@@ -1,3 +1,11 @@
+getaction(m::FreeAct, g::Type{G}) = m._1[1]
+getaction(m::FreeComp, g::Type{G}) = G()
+getaction(m::Pure, g::Type{G}) = G()
+
+getaction(m::FreeAct, s::Type{S}) = m._1[2]
+getaction(m::FreeComp, s::Type{S}) = S()
+getaction(m::Pure, s::Type{S}) = S()
+
 function dtreeθ(m::Act)
     g = Prim(TextGeom(; text="g,s", fontsize=1.0))
     lines = Prim(Line([[0, -1], [0, -8]]))
@@ -205,23 +213,25 @@ getmarkpath(M::Type{<:GeometricPrimitive}, d::TMark) = getmarkpath(mlift(M), d)
 getmarkpath(M::Type{<:GeometricPrimitive}, d::Mark) = getmarkpath(mlift(M), ζ(d))
 
 function getmarkpath(M::Type, d::Union{TMark,Mark}, g::Type{G})
-    return map(x -> x._1[1], getmarkpath(M, d))
+    return map(x -> getaction(x, g), getmarkpath(M, d))
 end
 function getmarkpath(M::Type, d::Union{TMark,Mark}, g::Type{S})
-    return map(x -> x._1[2], getmarkpath(M, d))
+    return map(x -> getaction(x, g), getmarkpath(M, d))
 end
-
 
 """
 getmarkpath(M::Vector{DataType}, d::Union{TMark,Mark})
 
 Given a TMark tree and a list of mark types, this function extracts a `Vector{TMark}`.
 """
-function getmarkpath(M::Vector{DataType}, d::Union{TMark,Mark})
+function getmarkpath(M::Vector{DataType}, d::TMark)
     return getmarkpath(M, [d])
 end
+function getmarkpath(M::Vector{DataType}, d::Mark)
+    return getmarkpath(M, [ζ(d)])
+end
 function getmarkpath(M::Vector{DataType}, d::Vector)
-    ap(t, diag) = mapreduce(x -> μ(fmap(ζ, x)), vcat, getmarkpath(t, diag))
-    vap(t, ds) = mapreduce(v -> mapreduce(x -> μ(fmap(ζ, x)), vcat, getmarkpath(t, v)), vcat, ds)
+    # ap(t, diag) = mapreduce(x -> μ(fmap(ζ, x)), vcat, getmarkpath(t, diag))
+    vap(t, ds) = mapreduce(v -> mapreduce(x -> μ(fmap(ζ, x)), vcat, getmarkpath(t, v), init=[]), vcat, ds, init=[])
     return foldl((acc, t) -> vap(t, acc), M, init=d)
 end

--- a/src/marks/plotspec.jl
+++ b/src/marks/plotspec.jl
@@ -99,6 +99,8 @@ function ζ(spec::PlotSpec)::𝕋{Mark}
         return T(figsize[1] / 2, figsize[2] / 2) * legends
     end
 
-    return (gridx + gridy + frame + xaxis + yaxis)↑(T(0, 10), title) →
+    stroke_frame = S(:fillOpacity => 0) * frame
+    background = S(:strokeWidth => 0) * frame
+    return (background + gridx + gridy + stroke_frame + xaxis + yaxis)↑(T(0, 10), title) →
            (T(10, frame.size[2]), legends)
 end

--- a/test/auxiliar/test_treemanipulation.jl
+++ b/test/auxiliar/test_treemanipulation.jl
@@ -1,0 +1,29 @@
+using Vizagrams
+using StructArrays
+
+@testset "Auxiliar Functions" begin
+
+    @testset "getmark" begin
+        d = Circle() + Circle() + Rectangle() + T(1, 1)Face() + S(:fill => :red)Face()
+
+        @test length(listmarks(d)) == 5
+        @test length(getmark(Circle, d)) == 2
+        @test length(getmark(Face, d)) == 2
+        @test length(getmark([Face, Circle], d)) == 6
+
+        @test length(listmarks(ζ(Face()))) == 4
+
+        @test length(getmarkpath(Face, d)) == 2
+
+        @test length(getmarkpath(Face, d, G)) == 2
+        @test all(getmarkpath(Face, d, G)[1]([1, 1]) .== [2, 2])
+        @test length(getmarkpath(Face, d, S)) == 2
+        @test getmarkpath(Face, d, S)[2].d[:fill] == :red
+
+        plt = plot(x=rand(10), y=rand(10))
+        @test getmarkpath([Plot], plt) == []
+        @test getmarkpath([Plot, PlotSpec], plt) == []
+        d = plt → plt
+        @test length(getmarkpath([Plot, PlotSpec, XAxis], d)) == 2
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,10 @@ using SafeTestsets
         include("./encoding/test_quickplot.jl")
     end
 
+    @safetestset "Auxiliar" begin
+        include("./auxiliar/test_treemanipulation.jl")
+    end
+
     # Tests below not working on GitHub Actions
     @safetestset "Visual Tests" begin
         include("./visual/plots.jl")


### PR DESCRIPTION
Two modifications.
- A fix for the frame, by splitting it into background and frame stroke;
- Modifying getmarkpath to allow nested types.