### PR TITLE
Replot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Vizagrams"
 uuid = "8c229dad-8b3a-4031-83d6-73545c88426d"
 authors = ["Davi Barreira <davisbarreira@gmail.com> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/Vizagrams.jl
+++ b/src/Vizagrams.jl
@@ -41,7 +41,7 @@ export uniformscaling, U, R, T, M, angle_between_vectors
 include("auxiliar/generate_ticks_ext_wilkinson.jl")
 export generate_tick_labels
 include("auxiliar/helperfunctions.jl")
-export getnested, setfields, insertcol, getcols, getcol, ⊗, hconcat
+export getnested, setfields, insertcol, getcols, getcol, ⊗, hconcat, vconcat
 
 # PRIMITIVES
 include("primitives/graphical_primitives.jl")

--- a/src/Vizagrams.jl
+++ b/src/Vizagrams.jl
@@ -1,6 +1,6 @@
 module Vizagrams
 
-using Accessors: Accessors, PropertyLens, insert, set, @set
+using Accessors: Accessors, PropertyLens, insert, set, @set, @delete
 using Colors: Color, Colorant, hex, RGB
 using ColorSchemes: ColorSchemes, ColorScheme, colorschemes
 using CoordinateTransformations:
@@ -199,5 +199,8 @@ include("scales/applyscales.jl")
 export applyscales
 
 include("encoding/context.jl")
+
+include("encoding/appendplot.jl")
+export replot
 
 end

--- a/src/auxiliar/helperfunctions.jl
+++ b/src/auxiliar/helperfunctions.jl
@@ -216,21 +216,21 @@ unzip(d) = d
     vconcat(d1::StructArray, d2::StructArray)
 Computes the outer unino of two struct arrays.
 """
-function vconcat(d1::StructArray, d2::StructArray)
+function vconcat(d1::StructArray, d2::StructArray; fill=nothing)
     cols1, cols2 = propertynames(d1), propertynames(d2)
     len1, len2 = length(d1), length(d2)
     is = intersect(cols1, cols2)
 
     # Concatenate common columns
     cols = union(cols1, cols2)
-    (StructArray ∘ NamedTuple)(
+    d = (StructArray ∘ NamedTuple)(
         map(cols) do col
             if col in is
                 return col => vcat(getcol(d1, col), getcol(d2, col))
             elseif col in cols1
-                return col => vcat(getcol(d1, col), map(x -> nothing, 1:len2))
+                return col => vcat(getcol(d1, col), map(x -> fill, 1:len2))
             elseif col in cols2
-                return col => vcat(map(x -> nothing, 1:len1), getcol(d2, col))
+                return col => vcat(map(x -> fill, 1:len1), getcol(d2, col))
             end
         end,
     )

--- a/src/auxiliar/helperfunctions.jl
+++ b/src/auxiliar/helperfunctions.jl
@@ -212,3 +212,26 @@ unzip(d) = d
 #     newcol = keys(nt)
 #     StructArray(NamedTuple{(cols..., newcol...)}((map(s -> get(data, s), cols)..., values(nt)...)))
 # end
+"""
+    vconcat(d1::StructArray, d2::StructArray)
+Computes the outer unino of two struct arrays.
+"""
+function vconcat(d1::StructArray, d2::StructArray)
+    cols1, cols2 = propertynames(d1), propertynames(d2)
+    len1, len2 = length(d1), length(d2)
+    is = intersect(cols1, cols2)
+
+    # Concatenate common columns
+    cols = union(cols1, cols2)
+    (StructArray ∘ NamedTuple)(
+        map(cols) do col
+            if col in is
+                return col => vcat(getcol(d1, col), getcol(d2, col))
+            elseif col in cols1
+                return col => vcat(getcol(d1, col), map(x -> nothing, 1:len2))
+            elseif col in cols2
+                return col => vcat(map(x -> nothing, 1:len1), getcol(d2, col))
+            end
+        end,
+    )
+end

--- a/src/encoding/appendplot.jl
+++ b/src/encoding/appendplot.jl
@@ -1,66 +1,66 @@
-"""
-    replot(plt::Plot,graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
-return Plot(plt.data, plt.spec,plt.graphic + graphic)
-"""
-function replot(plt::Plot, graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
-    return Plot(plt.data, plt.spec, plt.graphic + graphic)
-end
-function Base.:∘(plt::Plot, graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
-    return replot(plt, graphic)
-end
+# """
+#     replot(plt::Plot,graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
+# return Plot(plt.data, plt.spec,plt.graphic + graphic)
+# """
+# function replot(plt::Plot, graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
+#     return Plot(plt.data, plt.spec, plt.graphic + graphic)
+# end
+# function Base.:∘(plt::Plot, graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
+#     return replot(plt, graphic)
+# end
 
-"""
-    replot(plt::Plot, data::Union{StructArray,DataFrame,NamedTuple}; rescale=true)
+# """
+#     replot(plt::Plot, data::Union{StructArray,DataFrame,NamedTuple}; rescale=true)
 
-It vertically concatenates `plt.data` and `data` and creates a new plot.
-If `rescale` is true, it recomputes the scales, otherwise, it uses
-the scales from the original plot.
-"""
-function replot(
-    plt::Plot, data::Union{StructArray,NamedTuple}; enc=nothing, rescale=true, fill=nothing
-)
-    # turn data into StructArray
-    data = StructArray(Tables.rowtable(data))
-    data = vconcat(plt.data, data; fill=fill)
-    if !isnothing(enc)
-        scales = NamedTuple(
-            map(zip(keys(enc), values(enc))) do (k, v)
-                datatype = get(v, :datatype, infer_datatype(data))
-                scale = infer_encoding_scale(;
-                    data=data,
-                    coordinate=plt.spec.config.coordinate,
-                    framesize=plt.spec.config.figsize,
-                    variable=k,
-                    partial_encoding=v,
-                )
-                return (k => (datatype=datatype, scale=scale))
-            end,
-        )
-        enc = NamedTupleTools.rec_merge(unzip(enc), scales)
-    else
-        enc = NamedTuple()
-    end
-    encodings = NamedTupleTools.rec_merge(plt.encodings, enc)
+# It vertically concatenates `plt.data` and `data` and creates a new plot.
+# If `rescale` is true, it recomputes the scales, otherwise, it uses
+# the scales from the original plot.
+# """
+# function replot(
+#     plt::Plot, data::Union{StructArray,NamedTuple}; enc=nothing, rescale=true, fill=nothing
+# )
+#     # turn data into StructArray
+#     data = StructArray(Tables.rowtable(data))
+#     data = vconcat(plt.data, data; fill=fill)
+#     if !isnothing(enc)
+#         scales = NamedTuple(
+#             map(zip(keys(enc), values(enc))) do (k, v)
+#                 datatype = get(v, :datatype, infer_datatype(data))
+#                 scale = infer_encoding_scale(;
+#                     data=data,
+#                     coordinate=plt.spec.config.coordinate,
+#                     framesize=plt.spec.config.figsize,
+#                     variable=k,
+#                     partial_encoding=v,
+#                 )
+#                 return (k => (datatype=datatype, scale=scale))
+#             end,
+#         )
+#         enc = NamedTupleTools.rec_merge(unzip(enc), scales)
+#     else
+#         enc = NamedTuple()
+#     end
+#     encodings = NamedTupleTools.rec_merge(plt.spec.encodings, enc)
 
-    if rescale
-        enc_no_scale = NamedTuple(
-            map(zip(keys(plt.encodings), values(plt.encodings))) do (k, v)
-                k => @delete v.scale
-            end,
-        )
+#     if rescale
+#         enc_no_scale = NamedTuple(
+#             map(zip(keys(plt.spec.encodings), values(plt.spec.encodings))) do (k, v)
+#                 k => @delete v.scale
+#             end,
+#         )
 
-        encodings = NamedTupleTools.rec_merge(enc_no_scale, enc)
+#         encodings = NamedTupleTools.rec_merge(enc_no_scale, enc)
 
-        return Plot(; data=data, encodings=encodings, graphic=plt.graphic)
-    end
+#         return Plot(; data=data, encodings=encodings, graphic=plt.graphic)
+#     end
 
-    spec = plt.spec
-    spec = @set spec.encodings = encodings
-    return Plot(data, spec, plt.graphic)
-end
-function Base.:∘(plt::Plot, data::Union{StructArray,NamedTuple})
-    return replot(plt, data; rescale=true)
-end
+#     spec = plt.spec
+#     spec = @set spec.encodings = encodings
+#     return Plot(data, spec, plt.graphic)
+# end
+# function Base.:∘(plt::Plot, data::Union{StructArray,NamedTuple})
+#     return replot(plt, data; rescale=true)
+# end
 
 """
     replot(plt1::Plot, plt2::Plot)
@@ -68,7 +68,7 @@ end
 Place the graphic of `plt2` over `plt1`.
 """
 function replot(plt1::Plot, plt2::Plot)
-    encodings = NamedTupleTools.rec_merge(plt1.encodings, plt2.encodings)
+    encodings = NamedTupleTools.rec_merge(plt1.spec.encodings, plt2.spec.encodings)
     plt2 = @set plt2.spec.encodings = encodings
     plt2 = @set plt2.spec.config = (; guide=NilD())
     return plt1 + plt2

--- a/src/encoding/appendplot.jl
+++ b/src/encoding/appendplot.jl
@@ -1,0 +1,78 @@
+"""
+    replot(plt::Plot,graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
+return Plot(plt.data, plt.spec,plt.graphic + graphic)
+"""
+function replot(plt::Plot, graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
+    return Plot(plt.data, plt.spec, plt.graphic + graphic)
+end
+function Base.:∘(plt::Plot, graphic::Union{GeometricPrimitive,Prim,Mark,𝕋{Mark}})
+    return replot(plt, graphic)
+end
+
+"""
+    replot(plt::Plot, data::Union{StructArray,DataFrame,NamedTuple}; rescale=true)
+
+It vertically concatenates `plt.data` and `data` and creates a new plot.
+If `rescale` is true, it recomputes the scales, otherwise, it uses
+the scales from the original plot.
+"""
+function replot(
+    plt::Plot, data::Union{StructArray,NamedTuple}; enc=nothing, rescale=true, fill=nothing
+)
+    # turn data into StructArray
+    data = StructArray(Tables.rowtable(data))
+    data = vconcat(plt.data, data; fill=fill)
+    if !isnothing(enc)
+        scales = NamedTuple(
+            map(zip(keys(enc), values(enc))) do (k, v)
+                datatype = get(v, :datatype, infer_datatype(data))
+                scale = infer_encoding_scale(;
+                    data=data,
+                    coordinate=plt.spec.config.coordinate,
+                    framesize=plt.spec.config.figsize,
+                    variable=k,
+                    partial_encoding=v,
+                )
+                return (k => (datatype=datatype, scale=scale))
+            end,
+        )
+        enc = NamedTupleTools.rec_merge(unzip(enc), scales)
+    else
+        enc = NamedTuple()
+    end
+    encodings = NamedTupleTools.rec_merge(plt.encodings, enc)
+
+    if rescale
+        enc_no_scale = NamedTuple(
+            map(zip(keys(plt.encodings), values(plt.encodings))) do (k, v)
+                k => @delete v.scale
+            end,
+        )
+
+        encodings = NamedTupleTools.rec_merge(enc_no_scale, enc)
+
+        return Plot(; data=data, encodings=encodings, graphic=plt.graphic)
+    end
+
+    spec = plt.spec
+    spec = @set spec.encodings = encodings
+    return Plot(data, spec, plt.graphic)
+end
+function Base.:∘(plt::Plot, data::Union{StructArray,NamedTuple})
+    return replot(plt, data; rescale=true)
+end
+
+"""
+    replot(plt1::Plot, plt2::Plot)
+
+Place the graphic of `plt2` over `plt1`.
+"""
+function replot(plt1::Plot, plt2::Plot)
+    encodings = NamedTupleTools.rec_merge(plt1.encodings, plt2.encodings)
+    plt2 = @set plt2.spec.encodings = encodings
+    plt2 = @set plt2.spec.config = (; guide=NilD())
+    return plt1 + plt2
+end
+function Base.:∘(plt1::Plot, plt2::Plot)
+    return replot(plt1, plt2)
+end

--- a/src/encoding/quickplot.jl
+++ b/src/encoding/quickplot.jl
@@ -14,17 +14,8 @@ Provides a quicker way to specify a plot. For example:
 plot(df,x=:island,y=:species)
 ```
 """
-function plot(
-    data=nothing;
-    graphic=Circle(; r=3),
-    config=NamedTuple(),
-    figsize=(300, 200),
-    title="",
-    kwargs...,
-)
-    return Plot(;
-        data=data, graphic=graphic, config=config, figsize=figsize, title=title, kwargs...
-    )
+function plot(data = nothing; kwargs...)
+    return Plot(;data=data, kwargs...)
 end
 #     config = NamedTupleTools.rec_merge(
 #         (xaxis=(grid=(flag=true,),), yaxis=(grid=(flag=true,),)), config

--- a/test/auxiliar/test_helperfunctions.jl
+++ b/test/auxiliar/test_helperfunctions.jl
@@ -1,0 +1,16 @@
+using Vizagrams
+using StructArrays
+
+@testset "Helper Functions" begin
+    @testset "vconcat" begin
+        d1 = StructArray(x=[1, 2], c=["a", "b"])
+        d2 = StructArray(y=[10, 10, 10], x=[10, 10, 10], z=[1, 1, 1])
+        d = vconcat(d1, d2)
+
+        d = vconcat(d1, d2)
+        @test d.x == vcat(d1.x, d2.x)
+        @test d.c == vcat(d1.c, [nothing, nothing, nothing])
+        @test d.y == vcat([nothing, nothing], d2.y)
+        @test d.z == vcat([nothing, nothing], d2.z)
+    end
+end

--- a/test/encoding/test_quickplot.jl
+++ b/test/encoding/test_quickplot.jl
@@ -51,3 +51,25 @@ using StructArrays
     @test keys(plt.encodings) == (:color, :y, :x)
 end
 
+@testset "Replot" begin
+    Random.seed!(4)
+    plt = plot(x=rand(10), y=rand(10))
+
+    @testset "Replot with and without rescale" begin
+        @test string(draw(plt ∘ Line())) isa String
+        @test string(draw(replot(plt, StructArray(x=2rand(10), y=rand(10)), rescale=false))) isa String
+    end
+
+    @testset "Replot with plots" begin
+        f(x) = sin(x)
+        g(x) = cos(√x)
+        x = collect(0:0.01:10)
+        y = f.(x)
+        z = g.(x)
+
+        plt1 = Plot(x=x, y=y, graphic=Line())
+        plt2 = Plot(x=x, y=z, color=z, graphic=Circle(r=1))
+
+        @test string(draw(replot(plt1, plt2) → (plt1 ∘ plt2))) isa String
+    end
+end

--- a/test/encoding/test_quickplot.jl
+++ b/test/encoding/test_quickplot.jl
@@ -1,5 +1,6 @@
 using Vizagrams
 using StructArrays
+using Random
 
 @testset "Encoding Functions" begin
     # Testing whether the using functions in the encoding works
@@ -52,13 +53,13 @@ using StructArrays
 end
 
 @testset "Replot" begin
-    Random.seed!(4)
-    plt = plot(x=rand(10), y=rand(10))
+    # Random.seed!(4)
+    # plt = plot(x=rand(10), y=rand(10))
 
-    @testset "Replot with and without rescale" begin
-        @test string(draw(plt ∘ Line())) isa String
-        @test string(draw(replot(plt, StructArray(x=2rand(10), y=rand(10)), rescale=false))) isa String
-    end
+    # @testset "Replot with and without rescale" begin
+    #     @test string(draw(plt ∘ Line())) isa String
+    #     @test string(draw(replot(plt, StructArray(x=2rand(10), y=rand(10)), rescale=false))) isa String
+    # end
 
     @testset "Replot with plots" begin
         f(x) = sin(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,9 @@ using SafeTestsets
     @safetestset "Auxiliar" begin
         include("./auxiliar/test_treemanipulation.jl")
     end
+    @safetestset "Helper Functions" begin
+        include("./auxiliar/test_helperfunctions.jl")
+    end
 
     # Tests below not working on GitHub Actions
     @safetestset "Visual Tests" begin


### PR DESCRIPTION
"""
    replot(plt1::Plot, plt2::Plot)

Place the graphic of `plt2` over `plt1`.
"""
function replot(plt1::Plot, plt2::Plot)
    encodings = NamedTupleTools.rec_merge(plt1.spec.encodings, plt2.spec.encodings)
    plt2 = @set plt2.spec.encodings = encodings
    plt2 = @set plt2.spec.config = (; guide=NilD())
    return plt1 + plt2
end
function Base.:∘(plt1::Plot, plt2::Plot)
    return replot(plt1, plt2)
end
