### PR TITLE
add a user-friendly assert that catches the NaNs

### DIFF
--- a/src/primitives/envelopes.jl
+++ b/src/primitives/envelopes.jl
@@ -98,6 +98,7 @@ function stringinkbox(face::FTFont, str::String)
     ymin = mapreduce(x -> x[1][2], min, v)
     ymax = mapreduce(x -> x[2][2], max, v)
 
+    @assert !isnan(xmin) && !isnan(ymin) && !isnan(xmax) && !isnan(ymax) "inkbox computation resulted in NaNs (the font may be broken)"
     return [xmin, ymin], [xmax, ymax]
 end
 


### PR DESCRIPTION
...before they cause a really weird error elsewhere.

This is simple and hopefully mergeable part taken out of #67 and #68 (this change is correspondingly removed from there)